### PR TITLE
Remove bootstrap-flex

### DIFF
--- a/tasks/updater/scss.rb
+++ b/tasks/updater/scss.rb
@@ -12,7 +12,7 @@ class Updater
       log_processed "#{bootstrap_scss_files * ' '}"
 
       log_status 'Updating scss main files'
-      %w(bootstrap bootstrap-flex bootstrap-grid bootstrap-reboot).each do |name|
+      %w(bootstrap bootstrap-grid bootstrap-reboot).each do |name|
         # Compass treats non-partials as targets to copy into the main project, so make them partials.
         # Also move them up a level to clearly indicate entry points.
         from = "#{save_to}/#{name}.scss"


### PR DESCRIPTION
It's no longer part of bootstrap since 4.0.0 alpha 6
Fixes #66