### PR TITLE
fix undefined variable grid-breakpoints

### DIFF
--- a/templates/project/_bootstrap-variables.scss
+++ b/templates/project/_bootstrap-variables.scss
@@ -191,7 +191,7 @@
 //   lg: 992px,
 //   xl: 1200px
 // );
-@include _assert-starts-at-zero($grid-breakpoints);
+// @include _assert-starts-at-zero($grid-breakpoints);
 
 
 // Grid containers


### PR DESCRIPTION
Error on fresh alpha6 install using Rails 5:
![image](https://cloud.githubusercontent.com/assets/94511/22614219/41380e8a-ea34-11e6-9cd4-493002c9f582.png)
