### PR TITLE
Revert "Variables template: import functions and variables"

### DIFF
--- a/tasks/updater/scss.rb
+++ b/tasks/updater/scss.rb
@@ -23,18 +23,11 @@ class Updater
       end
 
       log_status 'Generating variable template file'
-      template_file_header = <<-SCSS
-// Override Bootstrap variables here (defaults from bootstrap v#{upstream_version}):
-
-@import "bootstrap/functions";
-@import "bootstrap/variables";
-
-SCSS
       save_file 'templates/project/_bootstrap-variables.scss',
-                template_file_header +
+                "// Override Bootstrap variables here (defaults from bootstrap v#{upstream_version}):\n" +
                     File.read("#{save_to}/_variables.scss").
                         # The instructions in the file header are replaced with the line above
-                        lines[5..-1].
+                        lines[4..-1].
                         join.
                         # Comment out the assignments
                         gsub(/^(?=[$@)}]|[ ]{2})/, '// ').

--- a/templates/project/_bootstrap-variables.scss
+++ b/templates/project/_bootstrap-variables.scss
@@ -1,8 +1,5 @@
 // Override Bootstrap variables here (defaults from bootstrap v4.0.0-beta):
-
-@import "bootstrap/functions";
-@import "bootstrap/variables";
-
+//
 // Variables should follow the `$component-state-property-size` formula for
 // consistent naming. Ex: $nav-link-disabled-color and $modal-content-box-shadow-xs.
 


### PR DESCRIPTION
Reverts twbs/bootstrap-rubygem#103

Unfortunately, it does not work for propagating changes from overwriten base variables, reverting.

```scss
$a: red !default;
$b: $a !default;

$a: blue;

$b: $a !default;

p {
    color: $b;
}
```

```css
p {
  color: red;
}
```