### PR TITLE
Bump up popper_js dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'popper_js', '>= 1.9.9'
+  gem 'popper_js', '>= 1.12.3'
 end
 
 group :debug do


### PR DESCRIPTION
Bumping up popper_js to fix the positioning issue with dropdowns and body or html tags styled at 100% height. See https://github.com/FezVrasta/popper.js/issues/302