### PR TITLE
Change first-child to first-of-type in btn-group

### DIFF
--- a/assets/stylesheets/bootstrap/_button-group.scss
+++ b/assets/stylesheets/bootstrap/_button-group.scss
@@ -37,19 +37,19 @@
 
 .btn-group {
   // Prevent double borders when buttons are next to each other
-  > .btn:not(:first-child),
-  > .btn-group:not(:first-child) {
+  > .btn:not(:first-of-type),
+  > .btn-group:not(:first-of-type) {
     margin-left: -$btn-border-width;
   }
 
   // Reset rounded corners
-  > .btn:not(:last-child):not(.dropdown-toggle),
-  > .btn-group:not(:last-child) > .btn {
+  > .btn:not(:last-of-type):not(.dropdown-toggle),
+  > .btn-group:not(:last-of-type) > .btn {
     @include border-right-radius(0);
   }
 
-  > .btn:not(:first-child),
-  > .btn-group:not(:first-child) > .btn {
+  > .btn:not(:first-of-type),
+  > .btn-group:not(:first-of-type) > .btn {
     @include border-left-radius(0);
   }
 }


### PR DESCRIPTION
Hello friends! Long-time listener, first-time caller 📞

This PR changes the selector for resetting rounded corners of `btn` elements in `btn-groups` from `first-child` to `first-of-type` to accommodate hidden inputs in sets of checkboxes or radio buttons.

The [Rails collection_check_box](https://apidock.com/rails/v5.2.3/ActionView/Helpers/FormOptionsHelper/collection_check_boxes) or [Simple Form](https://github.com/plataformatec/simple_form#collection-check-boxes) or [Formtastic](https://github.com/justinfrench/formtastic) all add a hidden input either at the beginning or end of a collection of check boxes or radio buttons. This makes implementing groups of checkboxes or radio buttons [as per the documentation](https://getbootstrap.com/docs/4.0/components/buttons/#checkbox-and-radio-buttons) either painful or slightly ugly. 

Hope this is the right place to put this PR!

<details>
<summary>Markup using Rails collection_check_boxes</summary>

![Screen Shot 2019-07-08 at 12 30 23 PM](https://user-images.githubusercontent.com/1615322/60775974-9c313d00-a17c-11e9-8439-72a74b7a6df5.png)
</details>

<details>
<summary>Screenshot using first-child/last-child</summary>

![Screen Shot 2019-07-08 at 12 30 07 PM](https://user-images.githubusercontent.com/1615322/60775961-802d9b80-a17c-11e9-9134-d663077630ab.png)
</details>

<details>
<summary>Screenshot using first-of-type/last-of-type</summary>

![Screen Shot 2019-07-08 at 12 32 42 PM](https://user-images.githubusercontent.com/1615322/60775966-858ae600-a17c-11e9-97b9-b54f9eebb869.png)
</details>