### PR TITLE
Support CDN usage

### DIFF
--- a/lib/bootstrap.rb
+++ b/lib/bootstrap.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bootstrap/version'
+require 'bootstrap/vendor'
 require 'popper_js'
 
 module Bootstrap

--- a/lib/bootstrap/vendor.rb
+++ b/lib/bootstrap/vendor.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Bootstrap
+  BOOTSTRAP_SHA    = "8fa0d3010112dca5dd6dd501173415856001ba8b"
+  VENDOR_VERSION   = "4.3.1"
+  VENDOR_INTEGRITY = {
+    "bootstrap.min.js" => "sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM",
+    "bootstrap.bundle.min.js" => "sha384-xrRywqdh3PHs8keKZN+8zzc5TX0GRTLCcmivcbNJWm2rs5C8PRhcEn3czEjhAO9o",
+    "bootstrap.min.css" => "sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T",
+  }
+end

--- a/lib/bootstrap/version.rb
+++ b/lib/bootstrap/version.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
 module Bootstrap
-  VERSION       = '4.3.1'
-  BOOTSTRAP_SHA = '8fa0d3010112dca5dd6dd501173415856001ba8b'
+  VERSION = '4.3.1'
 end


### PR DESCRIPTION
Using Bootstrap from CDN requires an exact version number that is not tied to gem releases.  Although historically `Bootstrap::VERSION` has mirrored the official Bootstrap version number, this might not always be the case.  Therefore, this patch adds `Bootstrap::VENDOR_VERSION`, which is updated by the updater task.

Additionally, it is best practice to employ subresource integrity hashes when using any public CDN.  To support this, this patch adds `Bootstrap::VENDOR_INTEGRITY`, which is a Hash mapping asset names to their properly-encoded integrity hashes.  This Hash is also updated by the updater task.

---

Here is an example of usage:
```html+erb
<script
  src="https://stackpath.bootstrapcdn.com/bootstrap/<%= Bootstrap::VENDOR_VERSION %>/js/bootstrap.bundle.min.js"
  integrity="<%= Bootstrap::VENDOR_INTEGRITY["bootstrap.bundle.min.js"] %>"
  crossorigin="anonymous"></script>
```

It would be nice to wrap that up in a helper method like `<%= Bootstrap.js_cdn_tag(bundle: true) %>`, but I wasn't sure if that would be considered outside the scope of this gem.  It would endorse a specific CDN, but perhaps that's acceptable, since it is the official Bootstrap CDN.  Also, the helper method should probably include something akin to `.try(:html_safe)`, which might feel out of place.

Either way, I can add mention of this to the README, if desired.
