### PR TITLE
Fix rake update when updating javascript assets does not copy the fil…

### DIFF
--- a/tasks/updater/js.rb
+++ b/tasks/updater/js.rb
@@ -5,8 +5,11 @@ class Updater
     def update_javascript_assets
       log_status 'Updating javascripts...'
       save_to  = @save_to[:js]
-      read_files('js/dist', bootstrap_js_files).each do |name, content|
-        save_file("#{save_to}/#{name}", remove_source_mapping_url(content))
+      contents = {}
+      bootstrap_js_files = get_paths_by_type('js/dist', /\.js$/)
+      read_files('js/dist', bootstrap_js_files).each do |name, file|
+        contents[name] = file
+        save_file("#{save_to}/#{name}", file)
       end
       log_processed "#{bootstrap_js_files * ' '}"
 


### PR DESCRIPTION
When running the rake update task, the update_javascript_assets failed to copy the twbs/bootstrap js/dist files locally. This change mirrors the logic for the updater/scss logic and saves only the .js files locally, ignorring the map files as previously defined in the old logic. 