### PR TITLE
[DOCS] Updates README with notice for Rails 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Bootstrap Ruby Gem [![Build Status](https://travis-ci.org/twbs/bootstrap-rubygem.svg?branch=master)](https://travis-ci.org/twbs/bootstrap-rubygem) [![Gem](https://img.shields.io/gem/v/bootstrap.svg)](https://rubygems.org/gems/bootstrap)
 
-[Bootstrap 4][bootstrap-home] ruby gem for Ruby on Rails (Sprockets) and Hanami (formerly Lotus).
+[Bootstrap 4][bootstrap-home] ruby gem for Ruby on Rails (*Sprockets*) and Hanami (formerly Lotus).
 
 For Sass versions of Bootstrap 3 and 2 see [bootstrap-sass](https://github.com/twbs/bootstrap-sass) instead.
+
+**Ruby on Rails 6 Note:**: 
+With the release of Rails 6 there have been some minor changes made to the default configuration for The Asset Pipeline. In specific, by default _Sprockets no longer processes JavaScript_ and instead Webpack is set as the default. The `twbs/bootstrap-rubygem` is for use with Sprockets not Webpack.
 
 ## Installation
 


### PR DESCRIPTION
From the thread #187 it is not obvious (yet) for newcomers to Rails 6 that the default configurations for The Asset Pipeline have changed, and that Sprockets no longer processes JavaScript. Because the TWBS gem is meant to be used specifically with Sprockets, this change adds a Rails 6 notice to avoid individuals getting confused. 

I wasn't sure if we want to add the method by which someone would add Bootstrap via webpack because that felt off topic from the gem's purpose. If we do I wrote a [blog](https://blog.robsdomain.com/twitter-bootstrap-in-rails-6/) on the topic on how to do so, and perhaps we could export some snippets of code. 

But I feel it's probably best to keep the README's focus on the gem specific functionality rather than advising on other deps like webpack.