### PR TITLE
Add Importmaps section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Bootstrap Ruby Gem [![Build Status](https://travis-ci.org/twbs/bootstrap-rubygem.svg?branch=master)](https://travis-ci.org/twbs/bootstrap-rubygem) [![Gem](https://img.shields.io/gem/v/bootstrap.svg)](https://rubygems.org/gems/bootstrap)
 
-[Bootstrap 5][bootstrap-home] ruby gem for Ruby on Rails (*Sprockets*) and Hanami (formerly Lotus).
+[Bootstrap 5][bootstrap-home] ruby gem for Ruby on Rails (*Sprockets*/*Importmaps*) and Hanami (formerly Lotus).
 
 For Sass versions of Bootstrap 3 and 2 see [bootstrap-sass](https://github.com/twbs/bootstrap-sass) instead.
 
-**Ruby on Rails 6 Note:**: 
-With the release of Rails 6 there have been some minor changes made to the default configuration for The Asset Pipeline. In specific, by default _Sprockets no longer processes JavaScript_ and instead Webpack is set as the default. The `twbs/bootstrap-rubygem` is for use with Sprockets not Webpack.
+**Ruby on Rails Note**: Newer releases of Rails have added additional ways for
+assets to be processed. The `twbs/bootstrap-rubygem` is for use with Importmaps
+or Sprockets, but not Webpack.
 
 ## Installation
 
@@ -57,6 +58,25 @@ gem 'jquery-rails'
 Bootstrap tooltips and popovers depend on [popper.js] for positioning.
 The `bootstrap` gem already depends on the
 [popper_js](https://github.com/glebm/popper_js-rubygem) gem.
+
+#### Importmaps
+
+You can pin either `bootstrap.js` or `bootstrap.min.js` in `config/importmap.rb`
+as well as `popper.js`:
+
+```ruby
+pin "bootstrap", to: "bootstrap.min.js", preload: true
+pin "@popperjs/core", to: "popper.js", preload: true
+```
+
+Whichever files you pin will need to be added to `config.assets.precompile`:
+
+```ruby
+# config/initializers/assets.rb
+Rails.application.config.assets.precompile += %w(bootstrap.min.js popper.js)
+```
+
+#### Sprockets
 
 Add Bootstrap dependencies and Bootstrap to your `application.js`:
 


### PR DESCRIPTION
### Summary

As importmap-rails is the default way to use javascript starting in
Rails 7, this should help users wanting to use Bootstrap without using
node.

---

### Original Summary

By adding bootstrap.js and bootstrap.min.js to the list of assets to
precompile, apps using importmaps will be able to

```ruby
pin "bootstrap", to: "bootstrap.min.js"
```

with no additional configuration.

### Other information

- As suggested in https://github.com/twbs/bootstrap-rubygem/issues/228#issuecomment-1011407591
- Similarly implemented in `turbo-rails`
https://github.com/hotwired/turbo-rails/blob/3355f2fae0a2bd3653ccccc62d9395b677c4ee1f/lib/turbo/engine.rb#L29-L35 