### PR TITLE
Fix: Replace color-adjust to print-color-adjust.

### DIFF
--- a/assets/stylesheets/bootstrap/_custom-forms.scss
+++ b/assets/stylesheets/bootstrap/_custom-forms.scss
@@ -13,7 +13,7 @@
   display: block;
   min-height: $font-size-base * $line-height-base;
   padding-left: $custom-control-gutter + $custom-control-indicator-size;
-  color-adjust: exact; // Keep themed appearance for print
+  print-color-adjust: exact; // Keep themed appearance for print
 }
 
 .custom-control-inline {


### PR DESCRIPTION
Hi everybody! First: Thanks for a rock solid gem!

The color-adjust shorthand is currently deprecated and makes autoprefixer complain.

I have a code base on 4.6 that I cannot upgrade to 5.0 any time soon, and this would fix the deprecation warnings from autoprefixer.

Cheers!