### PR TITLE
Soft-dependency to Sass engine to allow usage of SassC or Dart Sass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
 on:
-  push:
-  pull_request:
+  - push
+  - pull_request
+  - workflow_dispatch
 
 jobs:
   test:
@@ -18,7 +19,8 @@ jobs:
           - test/gemfiles/rails_5_2.gemfile
           - test/gemfiles/rails_6_0.gemfile
           - test/gemfiles/rails_6_1.gemfile
-          - test/gemfiles/rails_7_0.gemfile
+          - test/gemfiles/rails_7_0_sassc.gemfile
+          - test/gemfiles/rails_7_0_dartsass.gemfile
         include:
           - ruby_version: '2.5'
             gemfile: test/gemfiles/rails_4_2.gemfile
@@ -26,9 +28,13 @@ jobs:
             gemfile: test/gemfiles/rails_4_2.gemfile
         exclude:
           - ruby_version: '2.5'
-            gemfile: test/gemfiles/rails_7_0.gemfile
+            gemfile: test/gemfiles/rails_7_0_sassc.gemfile
+          - ruby_version: '2.5'
+            gemfile: test/gemfiles/rails_7_0_dartsass.gemfile
           - ruby_version: '2.6'
-            gemfile: test/gemfiles/rails_7_0.gemfile
+            gemfile: test/gemfiles/rails_7_0_sassc.gemfile
+          - ruby_version: '2.6'
+            gemfile: test/gemfiles/rails_7_0_dartsass.gemfile
           - ruby_version: '3.0'
             gemfile: test/gemfiles/rails_5_0.gemfile
           - ruby_version: '3.0'

--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ Add `bootstrap` to your Gemfile:
 gem 'bootstrap', '~> 5.3.1'
 ```
 
-Ensure that `sprockets-rails` is at least v2.3.2.
+This gem requires a Sass engine, so make sure you have **one** of these two gems in your Gemfile:
+- [`dartsass-sprockets`](https://github.com/tablecheck/dartsass-sprockets): Dart Sass engine, recommended but only works for Ruby 2.6+ and Rails 5+
+- [`sassc-rails`](https://github.com/sass/sassc-rails): SassC engine, deprecated but compatible with Ruby 2.3+ and Rails 4
+
+Also ensure that `sprockets-rails` is at least v2.3.2.
 
 `bundle install` and restart your server to make the files available through the pipeline.
 

--- a/Rakefile
+++ b/Rakefile
@@ -45,12 +45,20 @@ end
 
 desc 'Dumps output to a CSS file for testing'
 task :debug do
-  require 'sassc'
+  begin
+    require 'dartsass-ruby'
+  rescue LoadError
+    require 'sassc'
+  rescue LoadError
+    raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets or sassc-rails to your dependencies.")
+  end
   require './lib/bootstrap'
   require 'term/ansicolor'
   require 'autoprefixer-rails'
   path = Bootstrap.stylesheets_path
   %w(_bootstrap _bootstrap-reboot _bootstrap-grid).each do |file|
+    # For ease of upgrading, the root namespace ::SassC is still used by dartsass-sprockets.
+    # This is planned to be renamed in a future major version release.
     engine = SassC::Engine.new(File.read("#{path}/#{file}.scss"), syntax: :scss, load_paths: [path])
     out = File.join('tmp', "#{file[1..-1]}.css")
     css = engine.render

--- a/bootstrap.gemspec
+++ b/bootstrap.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.3'
 
   s.add_runtime_dependency 'popper_js', '>= 2.11.8', '< 3'
-
-  s.add_runtime_dependency 'sassc-rails', '>= 2.0.0'
   s.add_runtime_dependency 'autoprefixer-rails', '>= 9.1.0'
 
   # Testing dependencies

--- a/lib/bootstrap/engine.rb
+++ b/lib/bootstrap/engine.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 require 'autoprefixer-rails'
-require 'sassc-rails'
+begin
+  require 'dartsass-sprockets'
+rescue LoadError
+  require 'sassc-rails'
+rescue LoadError
+  raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets or sassc-rails to your dependencies.")
+end
 
 module Bootstrap
   module Rails

--- a/test/gemfiles/rails_4_2.gemfile
+++ b/test/gemfiles/rails_4_2.gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 gem 'actionpack', '~> 4.2.7'
 gem 'activesupport', '~> 4.2.7'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_5_0.gemfile
+++ b/test/gemfiles/rails_5_0.gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'actionpack', '~> 5.0.0'
 gem 'activesupport', '~> 5.0.0'
 gem 'autoprefixer-rails', '>= 6.3.6.1'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_5_1.gemfile
+++ b/test/gemfiles/rails_5_1.gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'actionpack', '~> 5.1.0'
 gem 'activesupport', '~> 5.1.0'
 gem 'autoprefixer-rails', '>= 7.1.1'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_5_2.gemfile
+++ b/test/gemfiles/rails_5_2.gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gem 'actionpack', '~> 5.2.8'
 gem 'activesupport', '~> 5.2.8'
 gem 'autoprefixer-rails', '>= 7.1.1'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'
-

--- a/test/gemfiles/rails_6_0.gemfile
+++ b/test/gemfiles/rails_6_0.gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'actionpack', '~> 6.0.3'
 gem 'activesupport', '~> 6.0.3'
 gem 'autoprefixer-rails', '>= 9.7.6'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'

--- a/test/gemfiles/rails_6_1.gemfile
+++ b/test/gemfiles/rails_6_1.gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'actionpack', '~> 6.1.3'
 gem 'activesupport', '~> 6.1.3'
 gem 'autoprefixer-rails', '>= 9.7.6'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'

--- a/test/gemfiles/rails_7_0_dartsass.gemfile
+++ b/test/gemfiles/rails_7_0_dartsass.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'actionpack', '~> 7.0.4'
+gem 'activesupport', '~> 7.0.4'
+gem 'autoprefixer-rails', '>= 9.7.6'
+gem 'dartsass-sprockets', '~> 3.0'
+
+gemspec path: '../../'

--- a/test/gemfiles/rails_7_0_sassc.gemfile
+++ b/test/gemfiles/rails_7_0_sassc.gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 gem 'actionpack', '~> 7.0.4'
 gem 'activesupport', '~> 7.0.4'
 gem 'autoprefixer-rails', '>= 9.7.6'
+gem 'sassc-rails', '~> 2.0'
 
 gemspec path: '../../'


### PR DESCRIPTION
Fix #255 

Removed the hard dependency to `sassc-rails` to allow the usage of `dartsass-sprockets` in newer applications, SassC being deprecated.