### PR TITLE
Support new SASS processors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ gem 'bootstrap', '~> 5.3.2'
 
 This gem requires a Sass engine, so make sure you have **one** of these two gems in your Gemfile:
 - [`dartsass-sprockets`](https://github.com/tablecheck/dartsass-sprockets): Dart Sass engine, recommended but only works for Ruby 2.6+ and Rails 5+
+- [`dartsass-rails`](https://github.com/rails/dartsass-rails): Dart Sass engine, recommended for Rails projects that use Propshaft
+- [`cssbundling-rails`](https://github.com/rails/cssbundling-rails): External Sass engine
 - [`sassc-rails`](https://github.com/sass/sassc-rails): SassC engine, deprecated but compatible with Ruby 2.3+ and Rails 4
 
 Also ensure that `sprockets-rails` is at least v2.3.2.

--- a/lib/bootstrap/engine.rb
+++ b/lib/bootstrap/engine.rb
@@ -7,7 +7,15 @@ rescue LoadError
   begin
     require 'sassc-rails'
   rescue LoadError
-    raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets or sassc-rails to your dependencies.")
+    begin
+      require 'dartsass-rails'
+    rescue LoadError
+      begin
+        require 'cssbundling-rails'
+      rescue LoadError
+        raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies.")
+      end
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

The gem currently only supports current-gem SASS processors - `dartsass-sprockets` and `sassc-rails`. The PR adds support for `dartsass-rails` and `cssbundling-rails`.

Closes https://github.com/twbs/bootstrap-rubygem/issues/247