### PR TITLE
Backport dartsass support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Add `bootstrap` to your Gemfile:
 gem 'bootstrap', '~> 4.6.2'
 ```
 
+This gem requires a Sass engine, so make sure you have **one** of these four gems in your Gemfile:
+- [`dartsass-sprockets`](https://github.com/tablecheck/dartsass-sprockets): Dart Sass engine, recommended but only works for Ruby 2.6+ and Rails 5+
+- [`dartsass-rails`](https://github.com/rails/dartsass-rails): Dart Sass engine, recommended for Rails projects that use Propshaft
+- [`cssbundling-rails`](https://github.com/rails/cssbundling-rails): External Sass engine
+- [`sassc-rails`](https://github.com/sass/sassc-rails): SassC engine, deprecated but compatible with Ruby 2.3+ and Rails 4
+
 Ensure that `sprockets-rails` is at least v2.3.2.
 
 `bundle install` and restart your server to make the files available through the pipeline.

--- a/Rakefile
+++ b/Rakefile
@@ -45,16 +45,28 @@ end
 
 desc 'Dumps output to a CSS file for testing'
 task :debug do
-  require 'sassc'
+  begin
+    require 'sass-embedded'
+  rescue LoadError
+    begin
+      require 'sassc'
+    rescue LoadError
+      raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets or sassc-rails to your dependencies.")
+    end
+  end
   require './lib/bootstrap'
   require 'term/ansicolor'
   require 'autoprefixer-rails'
   path = Bootstrap.stylesheets_path
   %w(_bootstrap _bootstrap-reboot _bootstrap-grid).each do |file|
-    engine = SassC::Engine.new(File.read("#{path}/#{file}.scss"), syntax: :scss, load_paths: [path])
-    out = File.join('tmp', "#{file[1..-1]}.css")
-    css = engine.render
+    filename = "#{path}/#{file}.scss"
+    css = if defined?(SassC::Engine)
+            SassC::Engine.new(File.read(filename), filename: filename, syntax: :scss).render
+          else
+            Sass.compile(filename).css
+          end
     css = AutoprefixerRails.process(css)
+    out = File.join('tmp', "#{file[1..-1]}.css")
     File.write(out, css)
     $stderr.puts Term::ANSIColor.green "Compiled #{out}"
   end

--- a/bootstrap.gemspec
+++ b/bootstrap.gemspec
@@ -15,8 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.3'
 
   s.add_runtime_dependency 'popper_js', '>= 1.16.1', '< 2'
-
-  s.add_runtime_dependency 'sassc-rails', '>= 2.0.0'
   s.add_runtime_dependency 'autoprefixer-rails', '>= 9.1.0'
 
   # Testing dependencies

--- a/lib/bootstrap/engine.rb
+++ b/lib/bootstrap/engine.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 require 'autoprefixer-rails'
-require 'sassc-rails'
+begin
+  require 'dartsass-sprockets'
+rescue LoadError
+  begin
+    require 'sassc-rails'
+  rescue LoadError
+    begin
+      require 'dartsass-rails'
+    rescue LoadError
+      begin
+        require 'cssbundling-rails'
+      rescue LoadError
+        raise LoadError.new("bootstrap-rubygem requires a Sass engine. Please add dartsass-sprockets, sassc-rails, dartsass-rails or cssbundling-rails to your dependencies.")
+      end
+    end
+  end
+end
 
 module Bootstrap
   module Rails

--- a/test/gemfiles/rails_7_0_dartsass.gemfile
+++ b/test/gemfiles/rails_7_0_dartsass.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'actionpack', '~> 7.0.4'
+gem 'activesupport', '~> 7.0.4'
+gem 'autoprefixer-rails', '>= 9.7.6'
+gem 'dartsass-sprockets', '~> 3.0'
+
+gemspec path: '../../'

--- a/test/gemfiles/rails_7_0_sassc.gemfile
+++ b/test/gemfiles/rails_7_0_sassc.gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'actionpack', '~> 7.0.4'
+gem 'activesupport', '~> 7.0.4'
+gem 'autoprefixer-rails', '>= 9.7.6'
+gem 'sassc-rails', '~> 2.0'
+
+gemspec path: '../../'


### PR DESCRIPTION
A combination of a few recent PRs that changed the dependency on SassC to soft and enabled support for dartsass-rails